### PR TITLE
exportRulesToCSV

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+      - development
+      - test*
     tags: ['*']
   pull_request:
   workflow_dispatch:
@@ -23,10 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.11'
-          - '1.10'
-          - '1.9'
-          - 'pre'
+          - 'lts' # long-term support
+          - '1' # to check the latest v1 version
+          - 'pre' # check upcoming releases
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhysiCellXMLRules"
 uuid = "bad69253-e2d7-49f9-a0cf-2fd158c7c32b"
 authors = ["Daniel Bergman <danielrbergman@gmail.com> and contributors"]
-version = "0.0.2"
+version = "0.0.3"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/test/ExportRulesTests.jl
+++ b/test/ExportRulesTests.jl
@@ -1,0 +1,37 @@
+using PhysiCellXMLRules
+
+function compare_csvs(csv_original::AbstractString, csv_exported::AbstractString)
+    csv_original_text = String[]
+    open(csv_original, "r") do f
+        global csv_original_text = readlines(f)
+    end
+
+    csv_exported_test = String[]
+    open(csv_exported, "r") do f
+        global csv_exported_test = readlines(f)
+    end
+
+    for line in csv_original_text
+        @test line in csv_exported_test
+    end
+    
+    for line in csv_exported_test
+        line = lstrip(line)
+        if startswith(line, "//")
+            continue
+        end
+        @test line in csv_original_text
+    end
+end
+
+xml_csv_pairs = [
+    ("./test.xml", "./cell_rules.csv"),
+    ("./test_empty.xml", "./cell_rules_empty.csv"),
+    ("./test_emptyish.xml", "./cell_rules_emptyish.csv")
+]
+
+for (path_to_xml, path_to_original_csv) in xml_csv_pairs
+    path_to_csv = "$(split(path_to_original_csv, ".")[1])_exported.csv"
+    exportRulesToCSV(path_to_csv, path_to_xml)
+    compare_csvs(path_to_original_csv, path_to_csv)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,4 +4,5 @@ using Test
 @testset "PhysiCellXMLRules.jl" begin
     # Write your tests here.
     include("./WriteRulesTests.jl")
+    include("./ExportRulesTests.jl")
 end


### PR DESCRIPTION
- exportRulesToCSV writes a csv file with the rules in the given xml file
- test with ExportRulesTests.jl
- docstrings for writeRules and exportRulesToCSV
- use abstract types for data structures and function signatures
- free xml_doc when done
- bump