### PR TITLE
use non-: version of custom data

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,5 +22,5 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/drbergman/PhysiCellXMLRules.jl",
-    devbranch="main",
+    devbranch="development",
 )

--- a/test/ExportRulesTests.jl
+++ b/test/ExportRulesTests.jl
@@ -5,12 +5,15 @@ function compare_csvs(csv_original::AbstractString, csv_exported::AbstractString
     csv_exported_test = readlines(csv_exported)
 
     for line in csv_original_text
+        if isempty(line) || startswith(line, "//")
+            continue
+        end
         @test line in csv_exported_test
     end
     
     for line in csv_exported_test
         line = lstrip(line)
-        if startswith(line, "//")
+        if isempty(line) || startswith(line, "//")
             continue
         end
         @test line in csv_original_text
@@ -24,7 +27,7 @@ xml_csv_pairs = [
 ]
 
 for (path_to_xml, path_to_original_csv) in xml_csv_pairs
-    path_to_csv = "$(split(path_to_original_csv, ".")[1])_exported.csv"
+    path_to_csv = "$(split(path_to_original_csv, ".csv")[1])_exported.csv"
     exportRulesToCSV(path_to_csv, path_to_xml)
     compare_csvs(path_to_original_csv, path_to_csv)
 end

--- a/test/WriteRulesTests.jl
+++ b/test/WriteRulesTests.jl
@@ -9,6 +9,7 @@ cell_type_3,pressure,decreases,cycle entry,0,1.0,4,0
 cell_type_3,contact with cell_type_5,increases,transform to cell_type_4,0.0001,0.01,4,0
 cell_type_4,substrate_1,decreases,migration speed,0,0.5,4,0
 cell_type_4,substrate_2,decreases,transform to cell_type_3,0.0,0.2,4,0
+cell_type_5,custom:sample,increases,custom:sample,100,0.01,4,0
 """
 
 open("cell_rules.csv", "w") do f
@@ -18,6 +19,9 @@ end
 writeRules("./test.xml", "./cell_rules.csv")
 n_rules = readchomp(`grep -c "<signal" ./test.xml`) |> x->parse(Int, x)
 @test n_rules == countlines(IOBuffer(csv_text))
+xml_lines = readlines("./test.xml")
+@test [contains(xml_line, "<behavior name=\"custom sample\">") for xml_line in xml_lines] |> sum == 1 # should be exactly one custom sample behavior
+@test [contains(xml_line, "<signal name=\"custom sample\">") for xml_line in xml_lines] |> sum == 1 # should be exactly one custom sample signal
 
 # ----------------------------
 open("cell_rules_empty.csv", "w") do f


### PR DESCRIPTION
PhysiCell defaults to using a : in custom data signals/behaviors. This interferes with pcvct using : for finding attributes in an XML path. Now, when reading in a CSV, make sure custom signals/behaviors are stored in the XML with the form "custom <name>". Then, when writing out, write to the form "custom:<name>".