### PR TITLE
support any capitalization of the signal type

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - development
     tags: ['*']
   pull_request:
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@
 /docs/Manifest.toml
 /docs/build/
 
+.DS_Store
 .vscode
+
+/test/*.csv
+/test/*.xml

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,6 +26,6 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/drbergman-lab/PhysiCellXMLRules.jl",
-    devbranch="development",
+    devbranch="main",
     push_preview=true,
 )

--- a/test/ExportRulesTests.jl
+++ b/test/ExportRulesTests.jl
@@ -65,3 +65,39 @@ exportCSVRules("./test_elementary_sans_type.csv", "./test_elementary_sans_type.x
 
 @test_throws AssertionError exportCSVRules("./test_elementary_sans_type.csv", "./test_elementary_sans_type.xml")
 exportCSVRules("./test_elementary_sans_type.csv", "./test_elementary_sans_type.xml"; force=true)
+
+#! test export with unsupported elementary signal type
+set_attribute(e_signal, "type", "unsupported_type")
+save_file(xml_doc, "./test_elementary_unsupported_type.xml")
+@test_throws PhysiCellXMLRules.UnsupportedSignalTypeError exportCSVRules("./test_elementary_unsupported_type.csv", "./test_elementary_unsupported_type.xml")
+try
+    exportCSVRules("./test_elementary_unsupported_type_2.csv", "./test_elementary_unsupported_type.xml")
+catch e
+    @test e isa PhysiCellXMLRules.UnsupportedSignalTypeError
+    @test e.cell_type == cell_type
+    @test e.behavior_name == behavior_name
+    @test e.signal_name == "pressure"
+    @test e.signal_type == "unsupported_type"
+    showerror(stdout, e)
+end
+
+#! test export with missing max_response in aggregator
+xml_doc = XMLDocument()
+xml_root = create_root(xml_doc, "behavior_rulesets")
+cell_type = "cd8"
+e = new_child(xml_root, "behavior_ruleset")
+set_attribute(e, "name", cell_type)
+behavior_name = "attack cancer"
+e = new_child(e, "behavior")
+set_attribute(e, "name", behavior_name)
+e_increasing = new_child(e, "increasing_signals") 
+e_signal_1 = new_child(e_increasing, "signal")
+set_attribute(e_signal_1, "name", "debris gradient")
+e_half_max_1 = new_child(e_signal_1, "half_max")
+set_content(e_half_max_1, "1e-3")
+e_hill_power_1 = new_child(e_signal_1, "hill_power")
+set_content(e_hill_power_1, "2")
+e_applies_to_dead_1 = new_child(e_signal_1, "applies_to_dead")
+set_content(e_applies_to_dead_1, "0")
+save_file(xml_doc, "./test_missing_max_response.xml")
+exportCSVRules("./test_missing_max_response.csv", "./test_missing_max_response.xml")

--- a/test/WriteRulesTests.jl
+++ b/test/WriteRulesTests.jl
@@ -22,8 +22,8 @@ writeXMLRules("./test.xml", "./cell_rules.csv")
 n_rules = readchomp(`grep -c "<signal" ./test.xml`) |> x->parse(Int, x)
 @test n_rules == countlines(IOBuffer(csv_text)) - 2
 xml_lines = readlines("./test.xml")
-@test [contains(xml_line, "<behavior name=\"custom sample\"") for xml_line in xml_lines] |> sum == 1 # should be exactly one custom sample behavior
-@test [contains(xml_line, "<signal name=\"custom sample\"") for xml_line in xml_lines] |> sum == 1 # should be exactly one custom sample signal
+@test [contains(xml_line, "<behavior name=\"custom:sample\"") for xml_line in xml_lines] |> sum == 1 # should be exactly one custom sample behavior
+@test [contains(xml_line, "<signal name=\"custom:sample\"") for xml_line in xml_lines] |> sum == 1 # should be exactly one custom sample signal
 
 # ----------------------------
 open("cell_rules_empty.csv", "w") do f


### PR DESCRIPTION
- struct UnsupportedSignalTypeError <: Exception
    cell_type::String
    behavior_name::String
    signal_name::String
    signal_type::String
end
- remove development branch from CI and docs
- no longer change custom: names (PCMM can handle something like `<signal name="custom:Notch">` just fine as `signal:name:custom:Notch` as it will split on `:` into 3 parts)
- handle missing max_response for aggregator export to CSV