### PR TITLE
Fix applies_to_dead being exported as 0 for every rule

### DIFF
--- a/src/export.jl
+++ b/src/export.jl
@@ -150,45 +150,52 @@ function exportAggregatorToCSV(io::IO, cell_type::AbstractString, behavior_name:
     exportAggregatorToCSV(io, cell_type, behavior_name, "", signals_element, response, indent)
 end
 
+function exportAppliesToDead(signal::XMLElement)
+    #! <applies_to_dead> is optional in the XML; an absent (or empty) element
+    #! means the rule does not apply to dead cells.
+    applies_to_dead = _parseBoolChild(signal, "applies_to_dead")
+    return _booleanToBinary(something(applies_to_dead, false))
+end
+
 function exportPartialHillSignalToCSV(io::IO, cell_type::AbstractString, signal::XMLElement, signal_name::String, response::Symbol, behavior_name::AbstractString, max_response::AbstractString)
     half_max = content(find_element(signal, "half_max"))
     hill_power = content(find_element(signal, "hill_power"))
-    applies_to_dead = content(find_element(signal, "applies_to_dead"))
+    applies_to_dead = exportAppliesToDead(signal)
     signal_name = parseSignalReference(signal_name, signal)
-    row = (cell_type, signal_name, response, behavior_name, max_response, half_max, hill_power, _booleanToBinary(applies_to_dead))
+    row = (cell_type, signal_name, response, behavior_name, max_response, half_max, hill_power, applies_to_dead)
     println(io, join(row, ","))
 end
 
 function exportHillSignalToCSV(io::IO, cell_type::AbstractString, signal::XMLElement, signal_name::String, response::Symbol, behavior_name::AbstractString, max_response::AbstractString)
     half_max = content(find_element(signal, "half_max"))
     hill_power = content(find_element(signal, "hill_power"))
-    applies_to_dead = content(find_element(signal, "applies_to_dead"))
+    applies_to_dead = exportAppliesToDead(signal)
     signal_name = parseSignalReference(signal_name, signal)
-    row = (cell_type, signal_name, "$response (hill)", behavior_name, max_response, half_max, hill_power, _booleanToBinary(applies_to_dead))
+    row = (cell_type, signal_name, "$response (hill)", behavior_name, max_response, half_max, hill_power, applies_to_dead)
     println(io, join(row, ","))
 end
 
 function exportIdentitySignalToCSV(io::IO, cell_type::AbstractString, signal::XMLElement, signal_name::String, response::Symbol, behavior_name::AbstractString, max_response::AbstractString)
-    applies_to_dead = content(find_element(signal, "applies_to_dead"))
+    applies_to_dead = exportAppliesToDead(signal)
     signal_name = parseSignalReference(signal_name, signal)
-    row = (cell_type, signal_name, "$response (identity)", behavior_name, max_response, "", "", _booleanToBinary(applies_to_dead))
+    row = (cell_type, signal_name, "$response (identity)", behavior_name, max_response, "", "", applies_to_dead)
     println(io, join(row, ","))
 end
 
 function exportLinearSignalToCSV(io::IO, cell_type::AbstractString, signal::XMLElement, signal_name::String, response::Symbol, behavior_name::AbstractString, max_response::AbstractString)
     signal_min = content(find_element(signal, "signal_min"))
     signal_max = content(find_element(signal, "signal_max"))
-    applies_to_dead = content(find_element(signal, "applies_to_dead"))
+    applies_to_dead = exportAppliesToDead(signal)
     signal_name = parseDirectionOfAbsoluteSignal(signal_name, signal)
-    row = (cell_type, signal_name, "$response (linear)", behavior_name, max_response, signal_min, signal_max, _booleanToBinary(applies_to_dead))
+    row = (cell_type, signal_name, "$response (linear)", behavior_name, max_response, signal_min, signal_max, applies_to_dead)
     println(io, join(row, ","))
 end
 
 function exportHeavisideSignalToCSV(io::IO, cell_type::AbstractString, signal::XMLElement, signal_name::String, response::Symbol, behavior_name::AbstractString, max_response::AbstractString)
     threshold = content(find_element(signal, "threshold"))
-    applies_to_dead = content(find_element(signal, "applies_to_dead"))
+    applies_to_dead = exportAppliesToDead(signal)
     signal_name = parseDirectionOfAbsoluteSignal(signal_name, signal)
-    row = (cell_type, signal_name, "$response (heaviside)", behavior_name, max_response, threshold, "", _booleanToBinary(applies_to_dead))
+    row = (cell_type, signal_name, "$response (heaviside)", behavior_name, max_response, threshold, "", applies_to_dead)
     println(io, join(row, ","))
 end
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -54,4 +54,3 @@ function getOrCreateElementByAttribute(parent_element::XMLElement, element_name:
 end
 
 _booleanToBinary(value::Bool) = value ? 1 : 0
-_booleanToBinary(value::String) = value == "true" ? 1 : 0

--- a/src/parse_xml.jl
+++ b/src/parse_xml.jl
@@ -216,6 +216,7 @@ function _parseBoolChild(parent_e::XMLElement, child_name::AbstractString)
     child = find_element(parent_e, child_name)
     isnothing(child) && return nothing
     text = strip(lowercase(content(child)))
+    isempty(text) && return nothing
     text in ("1", "true") && return true
     text in ("0", "false") && return false
     throw(ArgumentError("Could not parse <$child_name>$(text)</$child_name> as a boolean (expected 0/1/true/false)"))

--- a/test/ExportRulesTests.jl
+++ b/test/ExportRulesTests.jl
@@ -101,3 +101,63 @@ e_applies_to_dead_1 = new_child(e_signal_1, "applies_to_dead")
 set_content(e_applies_to_dead_1, "0")
 save_file(xml_doc, "./test_missing_max_response.xml")
 exportCSVRules("./test_missing_max_response.csv", "./test_missing_max_response.xml")
+
+#! test applies_to_dead export
+function applies_to_dead_column(path_to_csv::AbstractString)
+    lines = readlines(path_to_csv) .|> strip
+    filter!(line -> !isempty(line) && !startswith(line, "//"), lines)
+    return [split(line, ",")[end] for line in lines]
+end
+
+#! applies_to_dead=1 must survive the CSV -> XML -> CSV round trip for every
+#! elementary signal type
+csv_text = """
+cancer,pressure,decreases,cycle entry,0.0,0.5,8.0,0
+cancer,dead,increases,debris secretion,1.0,1.0e-10,1.0,1
+cd8,damage,increases (hill),apoptosis,1.0,30.0,10.0,1
+cd8,oxygen,increases (identity),migration speed,1.0,,,1
+cd8,pressure,increases (linear),migration bias,1.0,0.5,1.2,1
+cd8,time,increases (heaviside),attack cancer,1.0,10.0,,1
+"""
+
+open("cell_rules_applies_to_dead.csv", "w") do f
+    write(f, csv_text)
+end
+
+writeXMLRules("./test_applies_to_dead.xml", "./cell_rules_applies_to_dead.csv")
+exportCSVRules("./cell_rules_applies_to_dead_exported.csv", "./test_applies_to_dead.xml")
+compare_csvs("./cell_rules_applies_to_dead.csv", "./cell_rules_applies_to_dead_exported.csv")
+@test applies_to_dead_column("./cell_rules_applies_to_dead_exported.csv") == ["0", "1", "1", "1", "1", "1"]
+
+#! 0/1/true/false are all accepted (case- and whitespace-insensitively) and an
+#! absent or empty <applies_to_dead> means the rule does not apply to dead cells
+xml_doc = XMLDocument()
+xml_root = create_root(xml_doc, "behavior_rulesets")
+e = new_child(xml_root, "behavior_ruleset")
+set_attribute(e, "name", "cd8")
+e = new_child(e, "behavior")
+set_attribute(e, "name", "attack cancer")
+e_increasing = new_child(e, "increasing_signals")
+set_content(new_child(e_increasing, "max_response"), "1.0")
+
+applies_to_dead_variants = ["1", "true", " TRUE ", "0", "false", " False ", nothing, ""]
+for (i, applies_to_dead) in enumerate(applies_to_dead_variants)
+    e_variant = new_child(e_increasing, "signal")
+    set_attribute(e_variant, "name", "signal_$i")
+    set_content(new_child(e_variant, "half_max"), "1.0")
+    set_content(new_child(e_variant, "hill_power"), "2.0")
+    isnothing(applies_to_dead) || set_content(new_child(e_variant, "applies_to_dead"), applies_to_dead)
+end
+
+save_file(xml_doc, "./test_applies_to_dead_variants.xml")
+exportCSVRules("./test_applies_to_dead_variants.csv", "./test_applies_to_dead_variants.xml")
+@test applies_to_dead_column("./test_applies_to_dead_variants.csv") == ["1", "1", "1", "0", "0", "0", "0", "0"]
+
+#! an unparseable <applies_to_dead> is an error rather than a silent 0
+e_signal = new_child(e_increasing, "signal")
+set_attribute(e_signal, "name", "unparseable")
+set_content(new_child(e_signal, "half_max"), "1.0")
+set_content(new_child(e_signal, "hill_power"), "2.0")
+set_content(new_child(e_signal, "applies_to_dead"), "maybe")
+save_file(xml_doc, "./test_applies_to_dead_unparseable.xml")
+@test_throws ArgumentError exportCSVRules("./test_applies_to_dead_unparseable.csv", "./test_applies_to_dead_unparseable.xml")


### PR DESCRIPTION
`exportCSVRules` silently dropped `applies_to_dead`, writing `0` in the last CSV column for every rule regardless of the XML. Any user round-tripping a ruleset through XML and back lost the flag, and the resulting CSV looks valid — nothing errors, the column is just wrong.

## Mechanism

The exporters read the element's raw text and handed it to a `String` overload that only recognised the word `true`:

```julia
_booleanToBinary(value::String) = value == "true" ? 1 : 0
```

But `writeXMLRules` emits the element as `1`/`0` (via the `Bool` overload), and every fixture and example in the repo uses that form. So `<applies_to_dead>1</applies_to_dead>` mapped to `0`. All five elementary signal types were affected — partial_hill, hill, identity, linear, heaviside.

Separately, a missing `<applies_to_dead>` crashed the export outright with `MethodError: no method matching content(::Nothing)`, since `find_element` returned `nothing`.

## Before / after

Round-tripping `cell_rules.csv` → `writeXMLRules` → `exportCSVRules`, with the intermediate XML correctly containing `<applies_to_dead>1</applies_to_dead>` in all five cases:

```
# before                                                # after
cancer,dead,increases,debris secretion,1.0,1.0e-10,1.0,0    ...,1
cd8,damage,increases (hill),apoptosis,1.0,30.0,10.0,0       ...,1
cd8,oxygen,increases (identity),migration speed,1.0,,,0     ...,1
cd8,pressure,increases (linear),migration bias,1.0,0.5,1.2,0 ...,1
cd8,time,increases (heaviside),attack cancer,1.0,10.0,,0    ...,1
```

## Fix

All five exporters now go through one helper backed by the existing `_parseBoolChild`, which accepts `0`/`1`/`true`/`false` case- and whitespace-insensitively and throws on anything else:

```julia
function exportAppliesToDead(signal::XMLElement)
    #! <applies_to_dead> is optional in the XML; an absent (or empty) element
    #! means the rule does not apply to dead cells.
    applies_to_dead = _parseBoolChild(signal, "applies_to_dead")
    return _booleanToBinary(something(applies_to_dead, false))
end
```

An absent element now defaults to `0` instead of erroring. `_parseBoolChild` gained an `isempty` guard so an empty `<applies_to_dead/>` is treated as absent, mirroring `_parseFloatChild`; this also turns the parser's error message for that case from "could not parse" into the more accurate "missing `<applies_to_dead>`". The `_booleanToBinary(::String)` method is deleted so the trap cannot be reintroduced — it had no other callers.

`parseRulesXML` is unchanged in its strictness: it still requires `<applies_to_dead>` on elementary signals, matching the XSD. Only the CSV export defaults.

## Tests

15 new assertions in `test/ExportRulesTests.jl`: a full CSV → XML → CSV round trip with `applies_to_dead=1` across all five signal types, the accepted value forms (`0`, `1`, `true`, `false`, mixed case, surrounding whitespace), absent and empty elements both yielding `0`, and an unparseable value raising rather than silently exporting `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)