### PR TITLE
Fix composite signals truncating the rest of their aggregator on export

### DIFF
--- a/src/export.jl
+++ b/src/export.jl
@@ -114,10 +114,14 @@ function exportAggregatorToCSV(io::IO, cell_type::AbstractString, behavior_name:
 
         signal_type = something(attribute(signal, "type"), "partial_hill") |> lowercase
 
+        #! a composite signal is one entry in this aggregator, not the end of it:
+        #! recurse into it and carry on with its siblings
         if signal_type == "mediator"
-            return exportMediatorToCSV(io, cell_type, signal, behavior_name, indent, max_response; is_top_level=false)
+            exportMediatorToCSV(io, cell_type, signal, behavior_name, indent, max_response; is_top_level=false)
+            continue
         elseif signal_type == "aggregator"
-            return exportAggregatorToCSV(io, cell_type, behavior_name, max_response, signal, response, indent)
+            exportAggregatorToCSV(io, cell_type, behavior_name, max_response, signal, response, indent)
+            continue
         end
 
         signal_name = attribute(signal, "name")

--- a/test/ExportRulesTests.jl
+++ b/test/ExportRulesTests.jl
@@ -161,3 +161,37 @@ set_content(new_child(e_signal, "hill_power"), "2.0")
 set_content(new_child(e_signal, "applies_to_dead"), "maybe")
 save_file(xml_doc, "./test_applies_to_dead_unparseable.xml")
 @test_throws ArgumentError exportCSVRules("./test_applies_to_dead_unparseable.csv", "./test_applies_to_dead_unparseable.xml")
+
+
+#! test that a composite signal does not truncate its aggregator
+#! the same ruleset must export the same rows regardless of where the composite
+#! signal sits among its siblings
+function export_rows(rulesets, tag::AbstractString)
+    path_to_xml = "./test_composite_siblings_$(tag).xml"
+    path_to_csv = "./test_composite_siblings_$(tag).csv"
+    writeXMLRules(path_to_xml, rulesets; force=true)
+    exportCSVRules(path_to_csv, path_to_xml; force=true)
+    lines = readlines(path_to_csv) .|> strip
+    filter!(line -> !isempty(line) && !startswith(line, "//"), lines)
+    return lines
+end
+
+function composite_sibling_rulesets(mediator_first::Bool)
+    elementary = PhysiCellXMLRules.PartialHillSignal("pressure", 0.5, 4.0, false)
+    nested = PhysiCellXMLRules.MediatorSignal([PhysiCellXMLRules.HillSignal("oxygen", 2.0, 20.0, false)],
+                                              [PhysiCellXMLRules.HeavisideSignal("glucose", 10.0, false)])
+    signals = mediator_first ? [nested, elementary] : [elementary, nested]
+    increasing_signals = PhysiCellXMLRules.AggregatorSignal(PhysiCellXMLRules.AbstractSignal[signals...])
+    mediator = PhysiCellXMLRules.MediatorSignal(PhysiCellXMLRules.AggregatorSignal(PhysiCellXMLRules.AbstractSignal[]),
+                                                increasing_signals, nothing, 0.5, 1.2)
+    return [BehaviorRuleset("cd8", [PhysiCellXMLRules.Behavior("attack cancer", mediator)])]
+end
+
+rows_elementary_first = export_rows(composite_sibling_rulesets(false), "elementary_first")
+rows_mediator_first = export_rows(composite_sibling_rulesets(true), "mediator_first")
+
+#! the elementary sibling is exportable on its own and must survive either ordering
+@test "cd8,pressure,increases,attack cancer,1.2,0.5,4.0,0" in rows_elementary_first
+@test "cd8,pressure,increases,attack cancer,1.2,0.5,4.0,0" in rows_mediator_first
+@test sort(rows_elementary_first) == sort(rows_mediator_first)
+@test length(rows_mediator_first) == 3


### PR DESCRIPTION
`exportAggregatorToCSV` used `return` rather than `continue` when recursing into a `<signal type="mediator">` or `type="aggregator"`, so the first composite signal ended the sibling loop and every `<signal>` after it was dropped from the CSV silently.

CSV can't express a nested mediator, so the export is lossy for these rulesets either way — but the dropped siblings include ordinary elementary signals that export perfectly well on their own. The practical symptom is that output depends on sibling order:

```
AggregatorSignal([elementary, nested]) -> 3 rows
AggregatorSignal([nested, elementary]) -> 2 rows   # `pressure` silently missing
```

Both are the same ruleset, built through the public typed API — no hand-written XML needed. `test_super_advanced.xml` happens to put its mediator last, which is why the suite never caught this.

The recursion is one entry in the aggregator, not the end of it, so it now continues with the siblings.

## Tests

Four assertions in `test/ExportRulesTests.jl` build the same ruleset in both orderings and assert the exported rows are identical as sets, that the elementary sibling survives either way, and that the row count is 3. All three order-sensitive assertions fail against the unfixed exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)